### PR TITLE
Support for aiohttp 3.11.18

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,14 +45,14 @@ Shortcut
 --------
 
 Manual usage is too board. So I make shortcut to use easily.
-You just replace ``aiohttp.ClientSession`` to ``aiohttp_doh.ClientSession``.
+You just replace ``aiohttp.ClientSession`` to ``aiohttp_doh.DNSOverHTTPSClientSession``.
 
 .. code-block:: python3
 
-   from aiohttp_doh import ClientSession
+   from aiohttp_doh import DNSOverHTTPSClientSession
 
    async def main():
-       async with ClientSession() as session:
+       async with DNSOverHTTPSClientSession() as session:
            async with session.get('http://example.com') as resp:
                data = await resp.text()
 
@@ -68,7 +68,7 @@ endpoints
   List of str. DNS over HTTPS endpoints.
   Shortcut use `'https://dns.google.com/resolve'`
   and `'https://cloudflare-dns.com/dns-query'` both in default.
-  You can also use others instead.
+  You can also use others instead, make sure DNS endpoints support JSON response format (application/dns-json)
 
 json_loads
   Function for loads json. default is Python builtin json module's one.

--- a/tests/test_aiohttp_doh.py
+++ b/tests/test_aiohttp_doh.py
@@ -1,0 +1,27 @@
+import pytest
+from aiohttp import ClientSession, TCPConnector
+
+import aiohttp_doh
+from aiohttp_doh import DNSOverHTTPSClientSession
+
+pytest_plugins = ('pytest_asyncio',)
+
+
+@pytest.mark.asyncio
+async def test_DNSOverHTTPSResolver():
+    endpoints = [
+        'https://dns.google.com/resolve',
+        'https://cloudflare-dns.com/dns-query',
+    ]
+    resolver = aiohttp_doh.DNSOverHTTPSResolver(endpoints=endpoints)
+    connector = TCPConnector(resolver=resolver)
+    async with ClientSession(connector=connector) as session:
+        async with session.head("https://example.com") as response:
+            assert response.status == 200
+
+
+@pytest.mark.asyncio
+async def test_DNSOverHTTPSClientSession():
+    async with DNSOverHTTPSClientSession() as session:
+        async with session.head("https://example.com") as response:
+            assert response.status == 200


### PR DESCRIPTION
Some time ago i needed aiohttp competable library that could add DNS over HTTPS support to aiohttp requests, but sadly found only this one. It was not updated in pretty long time and from first use was not working. In this pull request i made changes that allowed it to work at python 3.13 version and aiohttp 3.11.18, everything was tested and i by myself using it in my own projects. 